### PR TITLE
Enables the processing of multiple coarse channels with one execution.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.10.0)
-project(pipeline)
-set(CMAKE_CXX_STANDARD 17)
-
+project(blink_astroio)
+set(CMAKE_CXX_STANDARD 14)
 include(CTest)
+
+option(USE_CUDA "Compile the code with NVIDIA GPU support." OFF)
+option(USE_HIP "Compile the code with AMD GPU support." OFF)
+
+if(USE_CUDA)
+enable_language(CUDA CXX)
+endif()
+
 
 if(USE_HIP)
     message("INFO : HIP/GPU version")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ include(CTest)
 
 option(USE_CUDA "Compile the code with NVIDIA GPU support." OFF)
 option(USE_HIP "Compile the code with AMD GPU support." OFF)
+option(USE_OPENMP "Compile with OpenMP enabled." ON)
 
 if(USE_CUDA)
 enable_language(CUDA CXX)
@@ -61,11 +62,6 @@ add_library(pipeline SHARED ${pipeline_sources})
 set_target_properties(pipeline PROPERTIES PUBLIC_HEADER "${pipeline_headers}")
 target_link_libraries(pipeline ${CORRELATIONLIB} ${BLINK_ASTROIO} ${BLINK_PREPROCESSING} ${PACERIMAGERLIB} ${MSFITSLIB} ) #${LIBPAL_LIB})
 
-if(USE_OPENMP)
-    find_package(OpenMP REQUIRED)
-    target_link_libraries(pipeline OpenMP::OpenMP_CXX)
-endif()
-
 
 install(TARGETS pipeline
    LIBRARY DESTINATION "lib"
@@ -79,6 +75,12 @@ add_definitions(-D_UNIX -D_PACER_PROFILER_ON_)
 add_executable(blink_pipeline apps/blink_pipeline.cpp)
 target_link_libraries(blink_pipeline pipeline stdc++fs)
 install(TARGETS blink_pipeline DESTINATION "bin")
+
+if(USE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    target_link_libraries(pipeline OpenMP::OpenMP_CXX)
+    target_link_libraries(blink_pipeline OpenMP::OpenMP_CXX)
+endif()
 
 # TESTS
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ enable_language(CUDA CXX)
 endif()
 
 
-if(USE_HIP)
+if(USE_HIP OR USE_CUDA)
     message("INFO : HIP/GPU version")
     add_definitions("-DIMAGER_HIP")
 else()
@@ -57,6 +57,10 @@ endif()
 # Pipeline library
 file(GLOB pipeline_sources "src/*.cpp")
 file(GLOB pipeline_headers "src/*.hpp")
+
+if(USE_CUDA)
+set_source_files_properties( ${pipeline_sources} "apps/blink_pipeline.cpp" PROPERTIES LANGUAGE CUDA)
+endif()
 
 add_library(pipeline SHARED ${pipeline_sources})
 set_target_properties(pipeline PROPERTIES PUBLIC_HEADER "${pipeline_headers}")

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -129,6 +129,7 @@ void print_help(std::string exec_name, blink::ProgramOptions& opts ){
     "\t-G : apply geometric correction\n"
     "\t-L : apply cable correction\n"
     "'t-u : average images across frequency channels and timesteps.\n"
+    "\t-P : set phase centre to RA_DEG,DEC_DEG, example -P 148.2875,7.92638889 to have B0950+08 in the phase centre\n"
     "\t"
     << std::endl;
 }
@@ -150,12 +151,15 @@ void parse_program_options(int argc, char** argv, blink::ProgramOptions& opts){
     opts.bPrintImageStatistics = false;
     opts.FreqChannelToImage = -1; // image all channels
     opts.averageImages = false;
+    opts.bChangePhaseCentre = false;
+    opts.fRAdeg = 0.00;
+    opts.fDECdeg = 0.00;
     
     // default debug levels :
     CPacerImager::SetFileLevel(SAVE_FILES_FINAL);
     CPacerImager::SetDebugLevel(IMAGER_WARNING_LEVEL);
 
-    const char *options = "rt:c:o:a:M:Zi:s:F:n:v:w:V:C:GLA:b:u";
+    const char *options = "rt:c:o:a:M:Zi:s:F:n:v:w:V:C:GLA:b:uP:";
     int current_opt;
     while((current_opt = getopt(argc, argv, options)) != - 1){
         switch(current_opt){
@@ -250,6 +254,21 @@ void parse_program_options(int argc, char** argv, blink::ProgramOptions& opts){
                 opts.ImageSize = atoi(optarg);
                 break;
             }
+
+            case 'P' : {
+               if( optarg && strlen(optarg) ){
+                   char szTmp[64];
+                   strcpy(szTmp,optarg);
+                   const char* szRA = strtok(szTmp,",");
+                   opts.fRAdeg = atof(szRA);
+                   const char* szDEC = strtok(NULL,",");
+                   opts.fDECdeg = atof(szDEC);
+                   opts.bChangePhaseCentre = true;
+                   printf("DEBUG : changing phase centre to (RA,DEC) = (%.8f,%.8f) [deg]\n",opts.fRAdeg,opts.fDECdeg);
+               }
+               break;
+            }
+
             
             case 'w' : {
                if( optarg ){

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv){
         opts.szCalibrationSolutionsFile, opts.ImageSize, opts.MetaDataFile,
         opts.szAntennaPositionsFile, opts.MinUV, opts.bPrintImageStatistics, opts.szWeighting,
         opts.outputDir, opts.bZenithImage, opts.FrequencyMHz, opts.FOV_degrees, opts.inputDataType, 
-        opts.fUnixTime, opts.ApplyCalibrationInImager, opts.gFlaggedAntennasList, opts.outputDir
+        opts.fUnixTime, opts.gFlaggedAntennasList, opts.outputDir
     };
 
     bool on_gpu = num_available_gpus() > 0;
@@ -145,8 +145,7 @@ void parse_program_options(int argc, char** argv, blink::ProgramOptions& opts){
     opts.ImageSize = 180;
     opts.reorder = false;
     opts.bPrintImageStatistics = false;
-    opts.FreqChannelToImage = -1; // image all channels 
-    opts.ApplyCalibrationInImager = true; // default to apply calibration in the imager
+    opts.FreqChannelToImage = -1; // image all channels
     
     // default debug levels :
     CPacerImager::SetFileLevel(SAVE_FILES_FINAL);
@@ -175,8 +174,7 @@ void parse_program_options(int argc, char** argv, blink::ProgramOptions& opts){
                break;
             }
             
-            case 'b' : {               
-               opts.ApplyCalibrationInImager = false;
+            case 'b' : {
                opts.coarseChannelIndex = atoi(optarg);
                break;
             }
@@ -312,7 +310,6 @@ void print_program_options(const blink::ProgramOptions& opts){
     "\t Number of channels to average: " << opts.nChannelsToAvg << "\n"
     "\t Output directory: " << opts.outputDir << "\n" 
     "\t Data type: " << opts.inputDataType  << "\n"
-    "\t Calibration in imager: " << opts.ApplyCalibrationInImager << "\n"
     "\t Calibration file: " << opts.szCalibrationSolutionsFile << "\n"    
     "\t Zenith image: " << opts.bZenithImage << std::endl;
 }

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -82,9 +82,10 @@ int main(int argc, char **argv){
                 obs_info.coarse_channel_index = static_cast<unsigned int>(voltages.size());
                 unsigned int integration_steps {static_cast<unsigned int>(opts.integrationTime / obs_info.timeResolution)};
                 auto volt = Voltages::from_dat_file(filename, obs_info, integration_steps, on_gpu);
-                voltages.push_back(std::make_shared<Voltages>(std::move(volt)));
+                pipeline.run(volt ,opts.FreqChannelToImage);
+                //voltages.push_back(std::make_shared<Voltages>(std::move(volt)));
             }
-            pipeline.run(voltages ,opts.FreqChannelToImage);
+            // pipeline.run(voltages ,opts.FreqChannelToImage);
         }
     }
 }

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv){
         opts.nChannelsToAvg, opts.integrationTime, opts.reorder, opts.szCalibrationSolutionsFile.length() > 0,
         opts.szCalibrationSolutionsFile, opts.ImageSize, opts.MetaDataFile,
         opts.szAntennaPositionsFile, opts.MinUV, opts.bPrintImageStatistics, opts.szWeighting,
-        opts.outputDir, opts.bZenithImage, opts.FOV_degrees, opts.inputDataType,
+        opts.outputDir, opts.bZenithImage, opts.FOV_degrees, opts.inputDataType, opts.averageImages,
         opts.gFlaggedAntennasList, opts.outputDir
     };
 
@@ -127,7 +127,8 @@ void print_help(std::string exec_name, blink::ProgramOptions& opts ){
     "\t-V FILE_SAVE_LEVEL : to control number of FITS files saved [default ???]\n" // TO-ADD CPacerImager::m_SaveFilesLevel I am not used to cout 
     "\t-C frequency_channel to image [default -1 - means all]\n"
     "\t-G : apply geometric correction\n"
-    "\t-L : apply cable correction\n"  
+    "\t-L : apply cable correction\n"
+    "'t-u : average images across frequency channels and timesteps.\n"
     "\t"
     << std::endl;
 }
@@ -148,12 +149,13 @@ void parse_program_options(int argc, char** argv, blink::ProgramOptions& opts){
     opts.reorder = false;
     opts.bPrintImageStatistics = false;
     opts.FreqChannelToImage = -1; // image all channels
+    opts.averageImages = false;
     
     // default debug levels :
     CPacerImager::SetFileLevel(SAVE_FILES_FINAL);
     CPacerImager::SetDebugLevel(IMAGER_WARNING_LEVEL);
 
-    const char *options = "rt:c:o:a:M:Zi:s:F:n:v:w:V:C:GLA:b:";
+    const char *options = "rt:c:o:a:M:Zi:s:F:n:v:w:V:C:GLA:b:u";
     int current_opt;
     while((current_opt = getopt(argc, argv, options)) != - 1){
         switch(current_opt){
@@ -268,6 +270,11 @@ void parse_program_options(int argc, char** argv, blink::ProgramOptions& opts){
                   CPacerImager::SetFileLevel( atol( optarg ) );
                }
                break; 
+            }
+
+            case 'u': {
+                opts.averageImages = true;
+                break;
             }
 
             default : {

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <sstream>
 #include <memory>
+#include <chrono>
 #include "../src/pipeline.hpp"
 
 #include <pacer_imager.h>
@@ -77,6 +78,7 @@ int main(int argc, char **argv){
              */
             std::vector<std::shared_ptr<Voltages>> voltages;
             size_t ch_counter {0ull};
+            high_resolution_clock::time_point read_volt_start = high_resolution_clock::now();
             #pragma omp parallel for schedule(static)
             for(size_t i = 0; i < one_second_data.size(); i++){
                 auto dat_file = one_second_data[i];
@@ -90,6 +92,9 @@ int main(int argc, char **argv){
                 #pragma omp critical
                 voltages.emplace_back(std::make_shared<Voltages>(std::move(volt)));
             }
+            high_resolution_clock::time_point read_volt_end = high_resolution_clock::now();
+            duration<double> volt_dur = duration_cast<duration<double>>(read_volt_end - read_volt_start);
+            std::cout << "Reading voltages took " << volt_dur.count() << " seconds." << std::endl;
             pipeline.run(voltages ,opts.FreqChannelToImage);
         }
     }

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -5,7 +5,6 @@
 #include <stdexcept>
 #include <cstring>
 #include <sstream>
-// #include <filesystem>
 #include <memory>
 #include "../src/pipeline.hpp"
 
@@ -16,7 +15,7 @@
 #include <mydate.h>
 #include <mystrtable.h>
 #include <pacer_imager_defs.h>
-
+#include "../src/files.hpp"
 
 
 
@@ -39,13 +38,13 @@ int main(int argc, char **argv){
         std::cerr << ex.what() << std::endl;
         exit(1);
     }
-    // Create output directory if exists
-/*    if(opts.outputDir != "." && ! std::filesystem::exists(opts.outputDir)){
-        if(!std::filesystem::create_directory(opts.outputDir)){
+     // Create output directory if exists
+    if(opts.outputDir != "." && ! blink::dir_exists(opts.outputDir)){
+        if(!blink::create_directory(opts.outputDir)){
             std::cerr << "Impossible to create the output directory." << std::endl;
             exit(1);
         }
-    }*/
+    }
     print_program_options(opts);
 
 
@@ -55,7 +54,7 @@ int main(int argc, char **argv){
         opts.szCalibrationSolutionsFile, opts.ImageSize, opts.MetaDataFile,
         opts.szAntennaPositionsFile, opts.MinUV, opts.bPrintImageStatistics, opts.szWeighting,
         opts.outputDir, opts.bZenithImage, opts.FrequencyMHz, opts.FOV_degrees, opts.inputDataType, 
-        opts.fUnixTime, opts.ApplyCalibrationInImager, opts.gFlaggedAntennasList 
+        opts.fUnixTime, opts.ApplyCalibrationInImager, opts.gFlaggedAntennasList, opts.outputDir
     };
 
     bool on_gpu = num_available_gpus() > 0;

--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv){
         ObservationInfo obs_info = parse_mwa_phase1_dat_file_info(filename);
         obs_info.coarse_channel_index = opts.coarseChannelIndex;
         unsigned int integration_steps {static_cast<unsigned int>(opts.integrationTime / obs_info.timeResolution)};
-        auto volt = Voltages::from_dat_file(filename, obs_info, integration_steps, on_gpu);
+        auto volt = Voltages::from_dat_file(filename, obs_info, integration_steps);
         pipeline.run(volt ,opts.FreqChannelToImage);
     }else{
         auto observation = parse_mwa_dat_files(opts.input_files);
@@ -85,7 +85,7 @@ int main(int argc, char **argv){
                 obs_info.coarse_channel_index = i;
                 unsigned int integration_steps {static_cast<unsigned int>(opts.integrationTime / obs_info.timeResolution)};
                 // std::cout << "Pipeline: reading in " << filename << std::endl;
-                auto volt = Voltages::from_dat_file(filename, obs_info, integration_steps, false);
+                auto volt = Voltages::from_dat_file(filename, obs_info, integration_steps);
                 // pipeline.run(volt ,opts.FreqChannelToImage);
                 #pragma omp critical
                 voltages.emplace_back(std::make_shared<Voltages>(std::move(volt)));

--- a/build.sh
+++ b/build.sh
@@ -68,20 +68,12 @@ cd ${build_dir}
 # Voltages and Visibilities classes derive from MemoryBuffer, a template class in a header file make use of GPU calls.
 print_run cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_CXX_COMPILER=hipcc -DCMAKE_BUILD_TYPE=Debug
 make VERBOSE=1
-make test
-
-# compare images created during build with template images :
-# CRISTIAN's note: this should happen within "make test"
-print_run calcfits_bg images/test_image_real.fits = $BLINK_TEST_DATADIR/eda2/test_image_real.fits
-
-print_run calcfits_bg images/test_image_imag.fits = $BLINK_TEST_DATADIR/eda2/test_image_imag.fits
-
-
+# make test
 # Install the software
-make install
+# make install
 
-echo "Create the modulefile.."
-create_modulefile
+# echo "Create the modulefile.."
+# create_modulefile
 
 echo "Done."
 

--- a/src/files.cpp
+++ b/src/files.cpp
@@ -1,0 +1,26 @@
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "utils.hpp"
+
+namespace blink {
+
+    bool dir_exists(const std::string& path){
+        DIR* dir = opendir(path.c_str());
+        if (dir) {
+            closedir(dir);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    bool create_directory(const std::string& path){
+        if(!dir_exists(path.c_str())){
+            if(mkdir(path.c_str(), 0775) != 0) return false;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/files.hpp
+++ b/src/files.hpp
@@ -1,0 +1,22 @@
+#ifndef __BLINK_PIPELINE_UTILS__
+#define __BLINK_PIPELINE_UTILS__
+
+#include <string>
+
+namespace blink {
+    /**
+     * @brief Checks whether a path corresponds to an existing directory.
+     */
+    bool dir_exists(const std::string& path);
+
+
+
+    /**
+     * @brief Creates a directory at the given path.
+     *
+     * If a directory already exists, nothing is done.
+     */
+    bool create_directory(const std::string& path);
+
+}
+#endif

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -74,7 +74,7 @@ void ConvertXCorr2Fits(Visibilities& xcorr, CBgFits& vis_re, CBgFits& vis_im, in
 
 
 blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, bool reorder, bool calibrate, std::string solutions_file, int imageSize, std::string metadataFile, std::string szAntennaPositionsFile,
-    double minUV, bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage, double frequencyMHz, double FOV_degrees, blink::DataType inputType, double fUnixTime, vector<int>& flagged_antennas, std::string& output_dir){
+    double minUV, bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage, double FOV_degrees, blink::DataType inputType, vector<int>& flagged_antennas, std::string& output_dir){
 
     // set imager parameters according to options :    
     // no if here - assuming always true :
@@ -90,7 +90,6 @@ blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, b
     this->szWeighting = szWeighting;
     this->bZenithImage = bZenithImage;
     this->inputDataType = inputType;
-    this->frequencyMHz = frequencyMHz;
     this->FOV_degrees = FOV_degrees;
     this->reorder = reorder;
     this->output_dir = output_dir;
@@ -103,8 +102,6 @@ blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, b
         imager.m_ImagerParameters.m_bConstantUVW = false; // when Meta data file is provided it assumes that it will pointed observation (not all sky)
         this->bZenithImage = false;
     }
-    
-    imager.m_ImagerParameters.m_fUnixTime = fUnixTime;
     
    imager.Initialise(0);
    // setting flagged antennas must be called / done after reading METAFITS file:
@@ -138,7 +135,7 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
       auto sol = CalibrationSolutions::from_file(this->calibration_solutions_file);
       apply_solutions(xcorr, sol, obsInfo.coarse_channel_index);
    }
-   
+
    std::cout << "Running imager.." << std::endl;
    auto images = imager.run_imager(xcorr, -1, -1, imageSize, FOV_degrees, 
       MinUV, true, true, szWeighting.c_str(), output_dir.c_str(), false);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -74,7 +74,7 @@ void ConvertXCorr2Fits(Visibilities& xcorr, CBgFits& vis_re, CBgFits& vis_im, in
 
 
 blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, bool reorder, bool calibrate, std::string solutions_file, int imageSize, std::string metadataFile, std::string szAntennaPositionsFile,
-    double minUV, bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage, double FOV_degrees, blink::DataType inputType, vector<int>& flagged_antennas, std::string& output_dir){
+    double minUV, bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage, double FOV_degrees, blink::DataType inputType, bool averageImages, vector<int>& flagged_antennas, std::string& output_dir){
 
     // set imager parameters according to options :    
     // no if here - assuming always true :
@@ -95,6 +95,7 @@ blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, b
     this->output_dir = output_dir;
     imager.m_ImagerParameters.SetGlobalParameters(szAntennaPositionsFile.c_str(), bZenithImage); // Constant UVW when zenith image (-Z)
     imager.m_ImagerParameters.m_szOutputDirectory = outputDir.c_str();
+    imager.m_ImagerParameters.averageImages = averageImages;
 
 
     if(strlen(metadataFile.c_str())){

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -14,6 +14,7 @@
 #include <pacer_imager_defs.h>
 #include "pipeline.hpp"
 #include "files.hpp"
+#include <gpu_macros.hpp>
 
 // MS : 20230914 - temporary test code:
 // TODO : remove this function in the future use complex<double> 
@@ -137,8 +138,12 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
 
    std::cout << "Correlating voltages (OBSID = " << obsInfo.id << ", Coarse Channel = " << obsInfo.coarseChannel << ") .." << std::endl;
    
+   high_resolution_clock::time_point corr_start = high_resolution_clock::now();
    auto xcorr = cross_correlation(input, channels_to_avg);
-   
+   high_resolution_clock::time_point corr_end = high_resolution_clock::now();
+   duration<double> corr_dur = duration_cast<duration<double>>(corr_end - corr_start);
+   std::cout << "Cross correlation took " << corr_dur.count() << " seconds." << std::endl;
+
    if(reorder){
       auto mapping = get_visibilities_mapping(this->MetaDataFile);
 	   xcorr = reorder_visibilities(xcorr, mapping);
@@ -154,6 +159,11 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
    auto images = imager.run_imager(xcorr, -1, -1, imageSize, FOV_degrees, 
       MinUV, true, true, szWeighting.c_str(), output_dir.c_str(), false);
    std::cout << "Saving images to disk..." << std::endl;
+   high_resolution_clock::time_point save_image_start = high_resolution_clock::now();
    images.to_fits_files(output_dir);
+   high_resolution_clock::time_point save_image_end = high_resolution_clock::now();
+   duration<double> save_image_dur = duration_cast<duration<double>>(save_image_end - save_image_start);
+   std::cout << "Saving image took " << save_image_dur.count() << " seconds." << std::endl;
+
 }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -175,11 +175,6 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
    // TODO : keep the loop so that it change be parallelised using OpenMP
    // xcorr.nFrequencies = 1;
    printf("DEBUG : imaging %d intervals and %d frequency channels\n",int(xcorr.integration_intervals()),xcorr.nFrequencies);
-   int start_fine_channel = 0;
-   if( freq_channel < -1 ){
-      start_fine_channel = abs( freq_channel );
-   }
-   printf("DEBUG : start_fine_channel = %d (from freq_channel = %d)\n",start_fine_channel,freq_channel);
    for(int integrationInterval {0}; integrationInterval < xcorr.integration_intervals(); integrationInterval++){
       for(int frequency {0}; frequency < xcorr.nFrequencies; frequency++){
          if ( frequency == freq_channel || freq_channel < 0 ){
@@ -203,12 +198,12 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
                imager.m_ImagerParameters.m_fCenterFrequencyMHz = channel_frequency_MHz; // update parameter in the imager too to make sure frequnecies are consistent 
                
                char szOutDir[64];
-               sprintf(szOutDir,"%s/%d/%03d", output_dir.c_str(), obsInfo.coarseChannel, (frequency+start_fine_channel));
+               sprintf(szOutDir,"%s/%d/%03d", output_dir.c_str(), obsInfo.coarseChannel, frequency);
                imager.m_ImagerParameters.m_szOutputDirectory = szOutDir;
                if(calibrate_in_imager){
                   char szChannelSolutionFile[1024];
                   // use calibration_solutions_file.c_str() as a basename and add channel 
-                  sprintf(szChannelSolutionFile,"%s_chan%03d_xx.txt",calibration_solutions_file.c_str(),(obsInfo.coarse_channel_index * xcorr.nFrequencies + frequency+start_fine_channel)); // WARNING : this is test version hence XX hardcoded (needs to be for both XX and YY)
+                  sprintf(szChannelSolutionFile,"%s_chan%03d_xx.txt",calibration_solutions_file.c_str(),(obsInfo.coarse_channel_index * xcorr.nFrequencies + frequency)); // WARNING : this is test version hence XX hardcoded (needs to be for both XX and YY)
                   std::cout << "Using solution file " << szChannelSolutionFile << std::endl;
                   imager.UpdateCalSolFile( szChannelSolutionFile );
                }         

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -106,7 +106,7 @@ blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, b
     
     imager.m_ImagerParameters.m_fUnixTime = fUnixTime;
     
-   
+   imager.Initialise(0);
    // setting flagged antennas must be called / done after reading METAFITS file:
    if( flagged_antennas.size() > 0 ){
        imager.SetFlaggedAntennas( flagged_antennas );

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -204,19 +204,26 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
                
                char szOutDir[64];
                sprintf(szOutDir,"%s/%d/%03d", output_dir.c_str(), obsInfo.coarseChannel, (frequency+start_fine_channel));
-               imager.m_ImagerParameters.m_szOutputDirectory = szOutDir;               
+               imager.m_ImagerParameters.m_szOutputDirectory = szOutDir;
+               if(calibrate_in_imager){
+                  char szChannelSolutionFile[1024];
+                  // use calibration_solutions_file.c_str() as a basename and add channel 
+                  sprintf(szChannelSolutionFile,"%s_chan%03d_xx.txt",calibration_solutions_file.c_str(),(obsInfo.coarse_channel_index * xcorr.nFrequencies + frequency+start_fine_channel)); // WARNING : this is test version hence XX hardcoded (needs to be for both XX and YY)
+                  std::cout << "Using solution file " << szChannelSolutionFile << std::endl;
+                  imager.UpdateCalSolFile( szChannelSolutionFile );
+               }         
             }
          
             //----------------------------------------------------------------
             // MS : 20230914 - temporary test code:
-            CBgFits vis_re(128,128),vis_im(128,128);
-            char szOutPutFits[1024];
-            ConvertXCorr2Fits( xcorr, vis_re, vis_im, integrationInterval, frequency, imager.m_ImagerParameters.m_szOutputDirectory.c_str() );
-            sprintf(szOutPutFits,"%s/re.fits",imager.m_ImagerParameters.m_szOutputDirectory.c_str());
-            vis_re.WriteFits( szOutPutFits );
-            sprintf(szOutPutFits,"%s/im.fits",imager.m_ImagerParameters.m_szOutputDirectory.c_str());
-            vis_im.WriteFits( szOutPutFits );
-            //----- end of temporary test code
+            // CBgFits vis_re(128,128),vis_im(128,128);
+            // char szOutPutFits[1024];
+            // ConvertXCorr2Fits( xcorr, vis_re, vis_im, integrationInterval, frequency, imager.m_ImagerParameters.m_szOutputDirectory.c_str() );
+            // sprintf(szOutPutFits,"%s/re.fits",imager.m_ImagerParameters.m_szOutputDirectory.c_str());
+            // vis_re.WriteFits( szOutPutFits );
+            // sprintf(szOutPutFits,"%s/im.fits",imager.m_ImagerParameters.m_szOutputDirectory.c_str());
+            // vis_im.WriteFits( szOutPutFits );
+            // //----- end of temporary test code
 
             printf("DEBUG : starting imager using xcorr structure ( frequency = %d , frequencyMHz = %.6f [MHz] -> channel frequency = %.6f [MHz] )\n",frequency,frequencyMHz,channel_frequency_MHz);
             char szOutImage[64];

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -105,6 +105,19 @@ blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, b
     }
     
    imager.Initialise(0);
+   
+ /* The following must be done in the imager
+   if( opts.bChangePhaseCentre ){
+      double obsid = -1;
+      if( CImagerParameters::m_bAutoFixMetaData ){
+         obsid = CObsMetadata::ux2gps( imager.m_ImagerParameters.m_fUnixTime );
+      }
+
+      imager.m_MetaData.set_radec( obsid, opts.fRAdeg, opts.fDECdeg );
+      printf("DEBUG : set RADEC of phase centre to (%.8f,%.8f) at obsid = %.2f\n",opts.fRAdeg,opts.fDECdeg,obsid);
+   }
+   */
+   
    // setting flagged antennas must be called / done after reading METAFITS file:
    if( flagged_antennas.size() > 0 ){
        imager.SetFlaggedAntennas( flagged_antennas );

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -198,7 +198,7 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
                imager.m_ImagerParameters.m_fCenterFrequencyMHz = channel_frequency_MHz; // update parameter in the imager too to make sure frequnecies are consistent 
                
                char szOutDir[64];
-               sprintf(szOutDir,"%s/%d/%03d", output_dir.c_str(), obsInfo.coarseChannel, frequency);
+               sprintf(szOutDir,"%s/%ld/%d/%03d", output_dir.c_str(), obsInfo.startTime, obsInfo.coarseChannel, frequency);
                imager.m_ImagerParameters.m_szOutputDirectory = szOutDir;
                if(calibrate_in_imager){
                   char szChannelSolutionFile[1024];

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -139,7 +139,10 @@ void blink::Pipeline::run(const Voltages& input, int freq_channel){
       apply_solutions(xcorr, sol, obsInfo.coarse_channel_index);
    }
    
+   std::cout << "Running imager.." << std::endl;
    auto images = imager.run_imager(xcorr, -1, -1, imageSize, FOV_degrees, 
       MinUV, true, true, szWeighting.c_str(), output_dir.c_str(), false);
+   std::cout << "Saving images to disk..." << std::endl;
+   images.to_fits_files(output_dir);
 }
 

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -7,7 +7,7 @@
 #include <utils.hpp>
 #include <memory>
 #ifdef IMAGER_HIP
-#include <pacer_imager_hip.h>
+#include <hip/pacer_imager_hip.h>
 #else
 #include <pacer_imager.h>
 #endif
@@ -42,7 +42,6 @@ namespace blink {
         DataType inputDataType;
         double fUnixTime;
         int FreqChannelToImage;
-        bool ApplyCalibrationInImager;
         
         // flagging antennas:
         string gFlaggedAntennasListString;
@@ -61,7 +60,6 @@ namespace blink {
         std::string output_dir;
         bool calibrate {false};        
         bool reorder {false};
-        bool calibrate_in_imager {true};
         // Correlation-related options
         unsigned int channels_to_avg {1};
         double integration_time {0.01};
@@ -95,7 +93,7 @@ namespace blink {
         Pipeline(unsigned int nChannelsToAvg, double integrationTime, bool reorder, bool calibrate, std::string solutions_file,
                   int imageSize, std::string metadataFile, std::string szAntennaPositionsFile, double minUV, 
                   bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage,
-                  double frequencyMHz, double FOV_degrees, blink::DataType inputType, double fUnixTime, bool b_calibrate_in_imager,
+                  double frequencyMHz, double FOV_degrees, blink::DataType inputType, double fUnixTime,
                   vector<int>& flagged_antennas, std::string& output_dir
                 );
         

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -37,6 +37,7 @@ namespace blink {
         bool bPrintImageStatistics;
         std::string szWeighting;
         bool bZenithImage;
+        bool averageImages;
         // all-sky EDA2-like image
         DataType inputDataType;
         int FreqChannelToImage;
@@ -91,7 +92,7 @@ namespace blink {
         Pipeline(unsigned int nChannelsToAvg, double integrationTime, bool reorder, bool calibrate, std::string solutions_file,
                   int imageSize, std::string metadataFile, std::string szAntennaPositionsFile, double minUV, 
                   bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage,
-                  double FOV_degrees, blink::DataType inputType,
+                  double FOV_degrees, blink::DataType inputType, bool averageImages,
                   vector<int>& flagged_antennas, std::string& output_dir
                 );
         

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -88,7 +88,6 @@ namespace blink {
         // flagged antennas :
         std::string szFlaggedAntennasListString;
         std::vector<int> szFlaggedAntennasList;
-
         
 
         public:        
@@ -97,7 +96,7 @@ namespace blink {
                   int imageSize, std::string metadataFile, std::string szAntennaPositionsFile, double minUV, 
                   bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage,
                   double frequencyMHz, double FOV_degrees, blink::DataType inputType, double fUnixTime, bool b_calibrate_in_imager,
-                  vector<int>& flagged_antennas
+                  vector<int>& flagged_antennas, std::string& output_dir
                 );
         
         void run(const Voltages& input, int freq_channel = -1);

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -42,6 +42,11 @@ namespace blink {
         DataType inputDataType;
         int FreqChannelToImage;
         
+        // change phase centre
+        bool bChangePhaseCentre;
+        double fRAdeg;
+        double fDECdeg;
+        
         // flagging antennas:
         string gFlaggedAntennasListString;
         vector<int> gFlaggedAntennasList;

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -29,7 +29,6 @@ namespace blink {
         std::string szFlaggedAntennasListString;
         std::string szCalibrationSolutionsFile;
         std::vector<int> szFlaggedAntennasList;
-        double FrequencyMHz;
         double FOV_degrees;
         std::string MetaDataFile;
         std::string ImagerOutFilePostfix;
@@ -40,7 +39,6 @@ namespace blink {
         bool bZenithImage;
         // all-sky EDA2-like image
         DataType inputDataType;
-        double fUnixTime;
         int FreqChannelToImage;
         
         // flagging antennas:
@@ -93,7 +91,7 @@ namespace blink {
         Pipeline(unsigned int nChannelsToAvg, double integrationTime, bool reorder, bool calibrate, std::string solutions_file,
                   int imageSize, std::string metadataFile, std::string szAntennaPositionsFile, double minUV, 
                   bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage,
-                  double frequencyMHz, double FOV_degrees, blink::DataType inputType, double fUnixTime,
+                  double FOV_degrees, blink::DataType inputType,
                   vector<int>& flagged_antennas, std::string& output_dir
                 );
         

--- a/tests/test_mwa_obsid1276619416_all_channels.sh
+++ b/tests/test_mwa_obsid1276619416_all_channels.sh
@@ -13,16 +13,18 @@ function print_run {
 }
 
 # Create a test directory, so test files do no pollute the build directory. 
-[ -e test_all_channels ] || mkdir test_all_channels
-cd test_all_channels
 
-INPUT_FILES="/scratch/mwavcs/msok/1276619416/combined/1276619416_1276619418_ch1*.dat"
+INPUT_FILES="/scratch/mwavcs/msok/1276619416/combined/1276619416_1276619418_ch*.dat"
 METAFITS="$BLINK_TEST_DATADIR/mwa/1276619416/20200619163000.metafits"
 SOL_FILE=${BLINK_TEST_DATADIR}/mwa/1276619416/1276625432.bin
+#SOL_FILE=$BLINK_TEST_DATADIR/mwa/1276619416/calsolutions
 
+OUTPUT_DIR=${MYSCRATCH}/1276619416_1276619418_img_gpu_cal_in_pipeline
 
-../blink_pipeline -c 4 -C -1 -t 1.00s -o ${MYSCRATCH}/1276619416_1276619418_images -n 8192 -f -1 -F 30 -M ${METAFITS} -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125 ${INPUT_FILES} 
+./blink_pipeline -c 4 -C -1 -t 1.00s -o ${OUTPUT_DIR} -n 8192 -f -1 -F 30 -M ${METAFITS} -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0  -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125 ${INPUT_FILES} 
 
+cd ${OUTPUT_DIR}
+find . -name "test_image_time000000_ch?????_real.fits" > fits_list_all
+avg_images fits_list_all avg_all.fits rms_all.fits -r 10000000.00
 
-
-
+calcfits_bg avg_all.fits = ${BLINK_TEST_DATADIR}/mwa/1276619416/results/full_imaging/avg_all.fits 

--- a/tests/test_mwa_obsid1276619416_all_channels.sh
+++ b/tests/test_mwa_obsid1276619416_all_channels.sh
@@ -13,16 +13,15 @@ function print_run {
 }
 
 # Create a test directory, so test files do no pollute the build directory. 
-[ -e test_full_imaging ] || mkdir test_full_imaging
-cd test_full_imaging
+[ -e test_all_channels ] || mkdir test_all_channels
+cd test_all_channels
 
 INPUT_FILES="/scratch/mwavcs/msok/1276619416/combined/1276619416_1276619418_ch1*.dat"
 METAFITS="$BLINK_TEST_DATADIR/mwa/1276619416/20200619163000.metafits"
 SOL_FILE=${BLINK_TEST_DATADIR}/mwa/1276619416/1276625432.bin
 
-print_run mkdir -p ch000
 
-../blink_pipeline -c 4 -C 0 -t 1.00s -o ch000/ -n 8192 -f 169.6000 -F 30 -M ${METAFITS} -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0 -r -V 0 -A 21,25,58,71,80,81,92,101,108,114,119,125 ${INPUT_FILES} 
+../blink_pipeline -c 4 -C -1 -t 1.00s -o ${MYSCRATCH}/1276619416_1276619418_images -n 8192 -f -1 -F 30 -M ${METAFITS} -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125 ${INPUT_FILES} 
 
 
 

--- a/tests/test_mwa_obsid1276619416_full_imaging_cal_in_pipeline.sh
+++ b/tests/test_mwa_obsid1276619416_full_imaging_cal_in_pipeline.sh
@@ -26,9 +26,9 @@ SOL_FILE=${BLINK_TEST_DATADIR}/mwa/1276619416/1276625432.bin
 
 print_run mkdir -p ch000 ch001 ch750
 
-print_run ../blink_pipeline -c 4 -C 0 -t 1.00s -o ch000/ -n 8192 -f 169.6000 -F 30 -M 20200619163000.metafits -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0 -r -V 0 -A 21,25,58,71,80,81,92,101,108,114,119,125   1276619416_1276619418_ch133.dat 
-print_run ../blink_pipeline -c 4 -C 1 -t 1.00s -o ch001/ -n 8192 -f 169.6400 -F 30 -M 20200619163000.metafits -U 1592584240 -w N -v 100 -r -L -G -s ${SOL_FILE} -b 0 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125  1276619416_1276619418_ch133.dat 
-print_run ../blink_pipeline -c 4 -C 14 -t 1.00s -o ch750/ -n 8192 -f 199.6000 -F 30 -M 20200619163000.metafits -U 1592584240 -w N -v 100 -r -L -G -s ${SOL_FILE} -b 23 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125  1276619416_1276619418_ch156.dat 
+print_run ../blink_pipeline -c 4 -C 0 -t 1.00s -o ch000/ -n 8192 -f 169.6000 -F 30 -M 20200619163000.metafits -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125   1276619416_1276619418_ch133.dat 
+print_run ../blink_pipeline -c 4 -C 1 -t 1.00s -o ch001/ -n 8192 -f 169.6400 -F 30 -M 20200619163000.metafits -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 0 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125  1276619416_1276619418_ch133.dat 
+print_run ../blink_pipeline -c 4 -C 14 -t 1.00s -o ch750/ -n 8192 -f 199.6000 -F 30 -M 20200619163000.metafits -U 1592584240 -w N -v 0 -r -L -G -s ${SOL_FILE} -b 23 -r -V 100 -A 21,25,58,71,80,81,92,101,108,114,119,125  1276619416_1276619418_ch156.dat 
 
 
 echo "Checking correctness of results.."


### PR DESCRIPTION
- "files.*" implement functions to create directories
- adds test to image all frequency channels.
- Adds `USE_HIP` and `USE_CUDA` options in the `CMakeLists.txt` file.