### PR TITLE
Implements remaining logic to change phase centre.

### DIFF
--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -97,7 +97,7 @@ int main(int argc, char **argv){
         opts.szCalibrationSolutionsFile, opts.ImageSize, opts.MetaDataFile,
         opts.szAntennaPositionsFile, opts.MinUV, opts.bPrintImageStatistics, opts.szWeighting,
         opts.outputDir, opts.bZenithImage, opts.FOV_degrees, opts.averageImages, opts.pol_to_image,
-        opts.gFlaggedAntennasList, dedisp_engine, opts.outputDir
+        opts.gFlaggedAntennasList, opts.bChangePhaseCentre, opts.fRAdeg, opts.fDECdeg, dedisp_engine, opts.outputDir
     };
 
     bool on_gpu = num_available_gpus() > 0;

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -25,7 +25,7 @@
 blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, bool reorder, bool calibrate, std::string solutions_file, 
     int imageSize, std::string metadataFile, std::string szAntennaPositionsFile, double minUV, bool printImageStats, 
     std::string szWeighting, std::string outputDir, bool bZenithImage, double FOV_degrees, bool averageImages, Polarization pol_to_image,
-    vector<int>& flagged_antennas,  Dedispersion& dedisp_engine, std::string& output_dir) : dedisp_engine {dedisp_engine} {
+    vector<int>& flagged_antennas, bool change_phase_centre, double ra_deg, double dec_deg, Dedispersion& dedisp_engine, std::string& output_dir) : dedisp_engine {dedisp_engine} {
 
     gpuGetDeviceCount(&num_gpus);
     if(num_gpus == 0){
@@ -59,6 +59,8 @@ blink::Pipeline::Pipeline(unsigned int nChannelsToAvg, double integrationTime, b
     for(int i {0}; i < num_gpus; i++){
         gpuSetDevice(i);
         imager[i] = new CPacerImagerHip {metadataFile, flagged_antennas, averageImages, pol_to_image};
+        if(change_phase_centre) imager[i]->m_MetaData.set_phase_centre(ra_deg, dec_deg);
+        
         if(i > 0) {
             if(calibrate) cal_sol[i] = cal_sol[0];
             if(reorder) mapping[i] = mapping[0];

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -58,7 +58,8 @@ namespace blink {
                   int imageSize, std::string metadataFile, std::string szAntennaPositionsFile, double minUV, 
                   bool printImageStats, std::string szWeighting, std::string outputDir, bool bZenithImage,
                   double FOV_degrees, bool averageImages, Polarization pol_to_image,
-                  vector<int>& flagged_antennas, Dedispersion& dedisp_engine, std::string& output_dir
+                  vector<int>& flagged_antennas,bool change_phase_centre, double ra_deg, double dec_deg,
+                  Dedispersion& dedisp_engine, std::string& output_dir
                 );
         
         void run(const Voltages& input, int gpu_id);


### PR DESCRIPTION
The option `-P` was already in the code, but it was not passed to the Pipeline constructor. Now, if requested, the Pipeline constructor will update the phase centre right after the Imager objects are constructed.

Here are some thoughts on why I chose to use a setter method in this case instead of adding three arguments  to the Imager constructor (that is, `bool change_phase`, `double ra`, `double dec`):

1. Changing phase centre is an optional feature, not required for the imager object to function properly (as opposed to the metadata file, for instance).
2. An initial phase centre is already decided before the imager is being constructed. That is, it is specified in the metadata file. We merely offer the option to change that. On the other hand, it is at the imager construction time that we decide whether we want to average the final images or not. There is a default for that option too, but the default "belongs" to the constructor in that case.
3. it is awkward to pass 3 parameters to code an action that is better defined with a setter method. We could have done the same for the flagged antennas, but it is only one argument and I think it can fit well in the constructor too. I moved the flagged antennas in the constructor because, in the previous imager version, there was a specific order needed to follow to call  the flagged antennas setter method and the `initialise` method. setter methods should in general be independent of other methods, or at least raise an exception?