### PR TITLE
Implements CPU RFI flagging and Dynamic Spectrum creation for a single pixel

### DIFF
--- a/src/dynamic_spectrum.cpp
+++ b/src/dynamic_spectrum.cpp
@@ -1,0 +1,30 @@
+#include <stdexcept>
+#include <memory_buffer.hpp>
+#include <images.hpp>
+#include <complex>
+#include "dynamic_spectrum.hpp"
+
+
+void DynamicSpectrum::add_images(const Images& images){
+    if(current_offset + images.integration_intervals() > n_timesteps)
+        throw std::runtime_error {"DynamicSpectrum::add_images: tried to add more points than accounted for in dynamic spectrum."};
+
+    #pragma omp parallel for collapse(2) schedule (static)
+    for(size_t interval {0}; interval < images.integration_intervals(); interval++){
+        for(size_t fine_channel {0}; fine_channel < images.nFrequencies; fine_channel++){
+            if(images.is_flagged(interval, fine_channel)) continue;
+            const std::complex<float>* image = images.at(interval, fine_channel);
+            float val = image[y * images.side_size + x].real();
+            // TODO make sure lower fine channels are shown at the bottom
+            this->data()[(images.obsInfo.coarse_channel_index * images.nFrequencies + fine_channel) * n_timesteps + current_offset + interval] = val;
+        }
+    }
+}
+
+void DynamicSpectrum::to_fits_file(std::string filename){
+    FITS fitsImage;
+    FITS::HDU hdu;
+    hdu.set_image(data(), n_timesteps, n_frequencies);    
+    fitsImage.add_HDU(hdu);
+    fitsImage.to_file(filename);
+}

--- a/src/dynamic_spectrum.hpp
+++ b/src/dynamic_spectrum.hpp
@@ -1,0 +1,28 @@
+#ifndef __DYNAMIC_SPECTRUM__
+#define __DYNAMIC_SPECTRUM__
+#include <cstring>
+#include <images.hpp>
+#include <memory_buffer.hpp>
+
+class DynamicSpectrum : MemoryBuffer<float> {
+
+    private:
+    size_t n_timesteps {0}, n_frequencies {0}, current_offset {0}, batch_size {0};
+    // image pixel coordinates this dynamic spectrum refers to
+    int x {0}, y {0};
+    
+    public:
+    DynamicSpectrum(size_t n_timesteps, size_t n_frequencies, size_t batch_size,  int x, int y) : \
+            MemoryBuffer {n_timesteps * n_frequencies}, n_timesteps {n_timesteps}, \
+            n_frequencies {n_frequencies}, x {x}, y {y}, batch_size {batch_size} {
+        std::memset(this->data(), 0, sizeof(float) * this->size());
+    }
+
+    void add_images(const Images& images);
+
+    void increase_offset() {current_offset += batch_size;};
+
+    void to_fits_file(std::string filename);
+};
+
+#endif

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -3,12 +3,15 @@
 
 #include <vector>
 #include <string>
+#include <memory>
 #include <astroio.hpp>
 #include <utils.hpp>
 #include <memory>
 #include <calibration.hpp>
 #include <gpu/pacer_imager_hip.h>
 #include <dedispersion.hpp>
+#include "dynamic_spectrum.hpp"
+
 
 using namespace blink::dedispersion;
 
@@ -19,6 +22,7 @@ namespace blink {
     class Pipeline {
 
         std::vector<CPacerImagerHip*> imager;
+        std::shared_ptr<DynamicSpectrum> pDynamicSp {nullptr};
         std::string output_dir, postfix;
         bool calibrate {false};
         bool reorder {false};
@@ -68,6 +72,8 @@ namespace blink {
         
         void run(const Voltages& input, int gpu_id);
         void run(const std::vector<std::shared_ptr<Voltages>>& inputs);
+        void set_dynamic_spectrum(std::shared_ptr<DynamicSpectrum> p) {pDynamicSp = p;};
+        void save_dynamic_spectrum() {pDynamicSp->to_fits_file(output_dir + "/dynamic_spectrum.fits");};
 
         ~Pipeline() {
             for(CPacerImagerHip* p : imager) delete p;

--- a/src/rfi_flagging.hpp
+++ b/src/rfi_flagging.hpp
@@ -4,6 +4,6 @@
 #include <vector>
 #include <images.hpp>
 
-std::vector<bool> flag_rfi(Images& images, double rms_threshold, int radius, bool compute_iqr);
+void flag_rfi(Images& images, double rms_threshold, int radius, bool compute_iqr);
 
 #endif


### PR DESCRIPTION
@marcinsokolowski Apologies, this PR is quite packed with functionalities that should have been two different PRs, but I ended up committing them on the same branch as I was working on them in parallel (I needed the DS to check the output of the RFI flagging).

# RFI Flagging

This PR introduces the source files `src/rfi_flagging.*` that implements a basic `rms`-based strategy to discard images with too high `rms`. These changes address https://github.com/PaCER-BLINK-Project/pipeline/issues/4

## RMS estimation strategies

I have implemented two methods to estimate `rms` of a vector of values:

- `compute_iqr_rms` based on the interquartile (iqr) strategy, where we discard extremes of the value range to then compute the `rms`. This requires sorting and *it is tricky to implement on GPU*.
- `compute_running_rms` (possibly to be renamed `compute_two_stage_rms`): computes the `mean` and `stdev` across all values. Coupled with a user-specified threshold value, these are used to discard outliers when computing the "true" `rms` on a second pass. This strategy is less ideal but easier to implement on GPUs, and still gives decent result.

## Computing RMS of an image

To compute the noise of an image, I select a (square) sub image centred at the image centre. It is just more efficient to have a square than a circle, and should not change much. I think that the iqr strategy here might be too sensitive as the images are very noisy at 20ms resolution.

## RFI & image flagging

With the above functions we can compute the rms for each image, which gives a vector of `rms` values. We can then use the same rms strategies on this vector to estimate the rms of the rms values, and to find the outliers. This is implemented in the `flag_rfi(Images& images, double rms_threshold, int radius, bool compute_iqr)` function that is then called in `pipeline.cpp`.

# Dynamic Spectrum generation

I have created a `DynamicSpectrum` (DS) class, which derives from `MemoryBuffer`. The constructor accepts parameters such as number of time bins and frequencies to allocate memory for.  When constructed in the BLINK pipeline, it will allocate enough memory to cover the entire number of processed seconds and fine channels. Basically, at the moment it creates a single dynamic spectrum for the entire processed data, for a single pixel.

The implementation is quite simple, the only notable method is `add_images` which will add the same pixel across time bins and frequencies in the DS buffer. The dynamic spectrum is built incrementally as images are generated for each second, so the code also needs to update the time offset from the start of the observation.

The `to_fits_file` method (possibly to be renamed `save_to_fits` to align it with the Images class) saves the dynamic spectrum as a fits file.

# Enabling RFI flagging and dynamic spectrum generation modes in the `blink-pipeline` CLI

Currently the RFI image flagging mode (that runs on CPU only), and the dynamic spectrum mode only works when the dedispersion mode is not enabled. This limitation will be removed in the future once the implementation matures. So, do not use the `-D -S` options if you want to play with RFI flagging and DS.

- `-f <threshold>` enables flagging of images whose rms has a SNR above `<threshold>`. *I have just realised that this is not what actually I implemented. There is a bug I will soon fix.* This mode only currently affects the output if used in conjunction with the dynamic spectrum generation. All images are still written to disk.
- `-d <x,y>` enable the DS mode, where images are used to generate the DS for the pixel (x,y). Example usage on the crab observation: `-d 387,904`. In this mode, only the dynamic spectrum is saved.

Example command line using both options:

```
srun -u  -n1 -c 64   `which blink_pipeline` -c 4  -t 20ms -o ${OUTPUT_DIR} -n 1024 -M ${METAFITS} -r -d 387,904 -X 868 -f 10  -Q 10  -s ${SOL_FILE} -b 0 -I  ${INPUT_FILES}  -A 11,16,30,44,49,53,55,59,60,63,65,72,73,76,79,80,82,84,87,93,95,110,123
```

Notice how I am now using the `-X` and `-Q` options only to create the DS for a small portion of the observation.
 
