### PR TITLE
Implements support for adding images to the dynamic spectrum using GPU.

### DIFF
--- a/src/dynamic_spectrum.cpp
+++ b/src/dynamic_spectrum.cpp
@@ -2,28 +2,90 @@
 #include <memory_buffer.hpp>
 #include <images.hpp>
 #include <complex>
+#include <mycomplex.hpp>
 #include "dynamic_spectrum.hpp"
 
+#define NTHREADS 1024
 
-void DynamicSpectrum::add_images(const Images& images){
+namespace {
+
+    __global__
+    void add_images_kernel(const Complex<float>* images, bool* flags, size_t image_side, size_t n_images, size_t n_channels,
+            int coarse_idx, size_t current_offset, size_t n_timesteps, int x, int y, float *ds){
+
+        const unsigned int grid_size {blockDim.x * gridDim.x};
+        size_t image_size {image_side * image_side};
+
+        for(size_t image_id {blockDim.x * blockIdx.x + threadIdx.x}; image_id < n_images; image_id += grid_size){
+            if(flags[image_id]) continue;
+            size_t fine_channel {image_id % n_channels};
+            size_t interval {image_id / n_channels};
+            const Complex<float>* image_px {images + image_id * image_size + y * image_side + x};
+            float val = (*image_px).real;
+            ds[(coarse_idx * n_channels + fine_channel) * n_timesteps + current_offset + interval] = val;
+        }
+    }
+
+
+    void add_images_cpu(Images& images, size_t current_offset, size_t n_timesteps, int x, int y, float* ds){
+        #pragma omp parallel for collapse(2) schedule (static)
+        for(size_t interval {0}; interval < images.integration_intervals(); interval++){
+            for(size_t fine_channel {0}; fine_channel < images.n_channels; fine_channel++){
+                if(images.is_flagged(interval, fine_channel)) continue;
+                const std::complex<float>* image = images.at(interval, fine_channel);
+                float val = image[y * images.side_size + x].real();
+                ds[(images.obsInfo.coarse_channel_index * images.n_channels + fine_channel) * n_timesteps + current_offset + interval] = val;
+            }
+        }
+    }
+
+
+    void add_images_gpu(Images& images, size_t current_offset, size_t n_timesteps, int x, int y, float* ds){
+        std::cout << "Running add_images_gpu.." << std::endl;
+        size_t n_images {images.size()};
+        auto flags = images.get_flags();
+        MemoryBuffer<bool> flagged_images {n_images};
+        if(flags.size()){
+            for(size_t i {0}; i < n_images; ++i) flagged_images[i] = flags[i];
+        }else{
+            for(size_t i {0}; i < n_images; ++i) flagged_images[i] = false;
+        }
+        flagged_images.to_gpu();
+        struct gpuDeviceProp_t props;
+        int gpu_id = -1;
+        gpuGetDevice(&gpu_id);
+        gpuGetDeviceProperties(&props, gpu_id);
+        unsigned int n_blocks = props.multiProcessorCount * 2;
+        add_images_kernel<<<n_blocks, NTHREADS>>>(reinterpret_cast<Complex<float>*>(images.data()), flagged_images.data(),
+            images.side_size, n_images, images.n_channels, images.obsInfo.coarse_channel_index, current_offset, n_timesteps, x, y, ds);
+        gpuCheckLastError();
+        gpuDeviceSynchronize();
+    }
+}
+
+
+void DynamicSpectrum::add_images(Images& images){
     if(current_offset + images.integration_intervals() > n_timesteps)
         throw std::runtime_error {"DynamicSpectrum::add_images: tried to add more points than accounted for in dynamic spectrum."};
 
-    #pragma omp parallel for collapse(2) schedule (static)
-    for(size_t interval {0}; interval < images.integration_intervals(); interval++){
-        for(size_t fine_channel {0}; fine_channel < images.n_channels; fine_channel++){
-            if(images.is_flagged(interval, fine_channel)) continue;
-            const std::complex<float>* image = images.at(interval, fine_channel);
-            float val = image[y * images.side_size + x].real();
-            // TODO make sure lower fine channels are shown at the bottom
-            this->data()[(images.obsInfo.coarse_channel_index * images.n_channels + fine_channel) * n_timesteps + current_offset + interval] = val;
-        }
+    #ifdef __GPU__
+    if(this->on_gpu() && gpu_support() && num_available_gpus() > 0){
+        images.to_gpu();
+        add_images_gpu(images, current_offset, n_timesteps, x, y, this->data());
+    }else{
+        images.to_cpu();
+        add_images_cpu(images, current_offset, n_timesteps, x, y, this->data());
     }
+    #else
+    add_images_cpu(images, current_offset, n_timesteps, x, y, this->data());
+    #endif
 }
+
 
 void DynamicSpectrum::to_fits_file(std::string filename){
     FITS fitsImage;
     FITS::HDU hdu;
+    this->to_cpu();
     hdu.set_image(data(), n_timesteps, n_frequencies);    
     fitsImage.add_HDU(hdu);
     fitsImage.to_file(filename);

--- a/src/dynamic_spectrum.hpp
+++ b/src/dynamic_spectrum.hpp
@@ -1,8 +1,11 @@
 #ifndef __DYNAMIC_SPECTRUM__
 #define __DYNAMIC_SPECTRUM__
 #include <cstring>
+#include <stdexcept>
 #include <images.hpp>
 #include <memory_buffer.hpp>
+
+// TODO: need to add support to managed memory for the MemoryBuffer class for this to work on GPU!!
 
 class DynamicSpectrum : MemoryBuffer<float> {
 
@@ -16,10 +19,19 @@ class DynamicSpectrum : MemoryBuffer<float> {
     DynamicSpectrum(size_t n_timesteps, size_t n_frequencies, size_t batch_size,  int x, int y) : \
             MemoryBuffer {n_timesteps * n_frequencies}, n_timesteps {n_timesteps}, \
             n_frequencies {n_frequencies}, x {x}, y {y}, batch_size {batch_size} {
-        std::memset(this->data(), 0, sizeof(float) * this->size());
+        if(false){
+            #ifdef __GPU__
+                gpuMemset(this->data(), 0,  sizeof(float) * this->size());
+            #else
+                throw std::runtime_error {"DynamicSpectrum: tried to allocate dynamic "
+                    "spectrum on GPU, but the code was not compiled with GPU support."};
+            #endif
+        }else{
+            std::memset(this->data(), 0, sizeof(float) * this->size());
+        }
     }
 
-    void add_images(const Images& images);
+    void add_images(Images& images);
 
     void increase_offset() {current_offset += batch_size;};
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -132,13 +132,15 @@ void blink::Pipeline::run(const Voltages& input, int gpu_id){
         clear_flagged_images_gpu(images);
     }
 
-    if(DynamicSpectra.size() > 0 ) {
-        std::cout << "Adding images to dynamic spectrum.." << std::endl;
-        images.to_cpu();
-        // TODO add GPU implementation
+    if(DynamicSpectra.size() > 0) {
+        std::cout << "Adding images to dynamic spectra.." << std::endl;
+        high_resolution_clock::time_point ds_start = high_resolution_clock::now();
         for( auto ds : DynamicSpectra ){
            ds->add_images(images);
         }
+        high_resolution_clock::time_point ds_end = high_resolution_clock::now();
+        duration<double> ds_dur = duration_cast<duration<double>>(ds_end - ds_start);
+        std::cout << "Adding to dynamic spectrum took " << ds_dur.count() << " seconds." << std::endl;
     }
     //if(rfi_marcin){
         // determine flags for images in the same time step


### PR DESCRIPTION
However, this implementation is not complete as the `MemoryBuffer` class does not yet handle Managed Memory allocation.

Because a dynamic spectrum receives contributions from all coarse channels that are distributed across multiple GPUs, it cannot be allocated on a single GPU. All GPUs must be able to write to this same memory location (the dynamic spectrum), to add their contributions. Hence, it is better to allocate the dynamic spectrum in Managed Memory. It will make it also easier to process it for RFI flagging as it is directly accessible to CPU.

I will add support for Managed Memory to the MemoryBuffer class in AstroIO. This, however, will require recompilation of all projects. It is a big change, but it improves the code base significantly.