### PR TITLE
ignoring of duplicated pixels for dynamic spectrum added 

### DIFF
--- a/apps/blink_pipeline.cpp
+++ b/apps/blink_pipeline.cpp
@@ -129,8 +129,12 @@ int main(int argc, char **argv){
         for( auto ds_pixel : opts.ds_pixels ){
            auto pDynamicSpectrum = std::make_shared<DynamicSpectrum>(observation.size() * n_timesteps,
                frequencies_list.size() - 1, n_timesteps, ds_pixel[0], ds_pixel[1]);
-           pipeline.add_dynamic_spectrum(pDynamicSpectrum);
-           std::cout << "Added dynamic spectrum for pixel " << ds_pixel[0] << "," << ds_pixel[1] << endl;
+           if( pipeline.has_dynamic_spectrum( ds_pixel[0], ds_pixel[1] ) ){
+              std::cout << "Duplicate pixel " << ds_pixel[0] << "," << ds_pixel[1] << " skipped" << endl;
+           }else{                   
+              pipeline.add_dynamic_spectrum(pDynamicSpectrum);           
+              std::cout << "Added dynamic spectrum for pixel " << ds_pixel[0] << "," << ds_pixel[1] << endl;
+           }
         }
         std::cout << "Enabled dynamic spectrum mode.." << std::endl;
     }

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -179,3 +179,11 @@ void blink::Pipeline::save_dynamic_spectra()
       cout << "Saved dynamic spectrum " << filename << endl;      
    }
 }
+
+bool blink::Pipeline::has_dynamic_spectrum(int x, int y)
+{
+   int count = count_if(begin(DynamicSpectra),end(DynamicSpectra),[x,y]( std::shared_ptr<DynamicSpectrum> dynaspec ){ if(x==dynaspec->x && y==dynaspec->y ){ return true; }else{return false;} } );
+   
+   return ( count > 0 );
+}
+

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -73,6 +73,7 @@ namespace blink {
         void run(const Voltages& input, int gpu_id);
         void run(const std::vector<std::shared_ptr<Voltages>>& inputs);
         void add_dynamic_spectrum(std::shared_ptr<DynamicSpectrum> p);
+        bool has_dynamic_spectrum(int x, int y);
         void save_dynamic_spectra();
 
         ~Pipeline() {


### PR DESCRIPTION
ignoring of duplicated pixels for dynamic spectrum added - can be useful if many pixels are copy/pasted from output of another script