### PR TITLE
no dynaspec overlaps 

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -182,7 +182,7 @@ void blink::Pipeline::save_dynamic_spectra()
 
 bool blink::Pipeline::has_dynamic_spectrum(int x, int y)
 {
-   int count = std::count_if(begin(DynamicSpectra),end(DynamicSpectra),[x,y]( std::shared_ptr<DynamicSpectrum> dynaspec ){ if(x==dynaspec->x && y==dynaspec->y ){ return true; }else{return false;} } );
+   int count = std::count_if(std::begin(DynamicSpectra),std::end(DynamicSpectra),[x,y]( std::shared_ptr<DynamicSpectrum> dynaspec ){ if(x==dynaspec->x && y==dynaspec->y ){ return true; }else{return false;} } );
    
    return ( count > 0 );
 }


### PR DESCRIPTION
Small update with std:: used whenever missing for code clarity.