### PR TITLE
Implements timestep flagging

### DIFF
--- a/src/gpu/timestep_rfi_flagging_gpu.cpp
+++ b/src/gpu/timestep_rfi_flagging_gpu.cpp
@@ -1,0 +1,112 @@
+#include <vector>
+#include <cmath>
+#include <iostream>
+#include <mycomplex.hpp>
+#include <images.hpp>
+#include <math.h>
+#include <memory_buffer.hpp>
+
+
+
+#define NTHREADS 1024
+#ifdef __NVCC__
+#define WARPSIZE 32
+#else
+#define WARPSIZE 64
+#endif
+#define NWARPS (NTHREADS / WARPSIZE)
+
+
+// test with blink-submit.py --centre  82.203949,21.861910 --obsid 1259685792   --dir-postfix "small_oversampling" --partition gpu-dev  --imgsize 256 --dyspec 1,1 --offset 186 --duration 30 --time 01:00:00
+
+__global__ void compute_timestep_rms_kernel(const Complex<float>*data, unsigned int side_size, unsigned int n_channels, unsigned int n_intervals, float *out_rms){
+
+    const unsigned int lane_id {threadIdx.x % warpSize};
+    const unsigned int warp_id {threadIdx.x / warpSize};
+    const unsigned int image_size {side_size * side_size};
+    const unsigned int n_images {n_channels * n_intervals};
+    const unsigned int center {side_size / 2};
+
+    // support array to compute block-wide reduction
+    __shared__ float support[2 * NWARPS];
+    
+    // each block handles a time step and all channels in it
+    for(unsigned int timestep {blockIdx.x}; timestep < n_intervals; timestep += gridDim.x){
+        float sum {0.0f}, sum2 {0.0f};
+        for(size_t channel {threadIdx.x}; channel < n_channels; channel += blockDim.x){
+            size_t image_id {timestep * n_channels + channel};
+            const Complex<float>* center_image {data + image_id * image_size + center * side_size + center};
+            float val {center_image->real};
+            sum += val;
+            sum2 += val*val;
+        }
+        for(unsigned int i {warpSize / 2}; i >= 1; i /= 2){
+            float up_sum = __gpu_shfl_down(sum, i);
+            float up_sum2 = __gpu_shfl_down(sum2, i);
+            if(lane_id < i){
+                sum += up_sum;
+                sum2 += up_sum2;
+            }
+            #ifdef __NVCC__
+            __syncwarp();
+            #endif
+        }
+        if(lane_id == 0 && warp_id > 0) {
+            support[warp_id] = sum;
+            support[NWARPS + warp_id] = sum2;
+        }
+        __syncthreads();
+        if(warp_id == 0){
+            if(lane_id > 0 && lane_id < NWARPS) {
+                sum = support[lane_id];
+                sum2 = support[NWARPS + lane_id];
+            }
+            #ifdef __NVCC__
+            __syncwarp();
+            #endif
+            for(unsigned int i {NWARPS / 2}; i >= 1; i /= 2){
+                float up_sum = __gpu_shfl_down(sum, i, NWARPS);
+                float up_sum2 = __gpu_shfl_down(sum2, i, NWARPS);
+                if(lane_id < i){
+                    sum += up_sum;
+                    sum2 += up_sum2;
+                }
+                #ifdef __NVCC__
+                __syncwarp();
+                #endif
+            }
+            if(lane_id == 0){
+                float mean {sum / n_channels};
+                float stdev {sqrt(sum2 / n_channels- mean*mean)};
+                out_rms[timestep] = stdev;
+            }
+        }
+        __syncthreads();
+    }
+}
+
+
+
+/**
+    @brief: computes a vector of boolean values indicating which of the input images are contaminated
+    by RFI. The function uses a high RMS as a signal for bad/corrupted channels.
+*/
+std::vector<float> compute_timestep_rms_gpu(Images& images){
+    std::cout << "compute_timestep_rms_gpu.." << std::endl;
+    images.to_gpu();
+    size_t n_images = images.size();
+    MemoryBuffer<float> rms_vector_mb {images.n_intervals, true};
+    std::vector<float> rms_vector(images.n_intervals);
+    struct gpuDeviceProp_t props;
+    int gpu_id = -1;
+    gpuGetDevice(&gpu_id);
+    gpuGetDeviceProperties(&props, gpu_id);
+    unsigned int n_blocks = props.multiProcessorCount * 2;
+    compute_timestep_rms_kernel<<<n_blocks, NTHREADS>>>(reinterpret_cast<Complex<float>*>(images.data()),
+        static_cast<unsigned int>(images.side_size), static_cast<unsigned int>(images.n_channels),
+        static_cast<unsigned int>(images.n_intervals), rms_vector_mb.data());
+    gpuCheckLastError();
+    gpuMemcpy(rms_vector.data(), rms_vector_mb.data(), sizeof(float) * images.n_intervals, gpuMemcpyDeviceToHost);
+    gpuDeviceSynchronize();
+    return rms_vector;
+}

--- a/src/gpu/timestep_rfi_flagging_gpu.hpp
+++ b/src/gpu/timestep_rfi_flagging_gpu.hpp
@@ -1,0 +1,9 @@
+#ifndef __TIMESTEP_RFI_GPU__
+#define __TIMESTEP_RFI_GPU__
+
+#include <vector>
+#include <images.hpp>
+
+std::vector<float> compute_timestep_rms_gpu(Images& images);
+
+#endif

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -20,7 +20,7 @@
 #include <gpu_macros.hpp>
 #include "rfi_flagging.hpp"
 #include "gpu/rfi_flagging_gpu.hpp"
-
+#include "timestep_rfi_flagging.hpp"
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -125,10 +125,9 @@ void blink::Pipeline::run(const Voltages& input, int gpu_id){
     auto images = imager[gpu_id]->run(xcorr);
    
     if(rfi_flagging > 0){
-        // images.to_cpu();
         std::cout << "Applying RFI flagging..." << std::endl;
-        //flag_rfi_cpu(images, rfi_flagging, 50, false);
         flag_rfi(images, rfi_flagging, true);
+        flag_timestep_rfi(images, rfi_flagging, true);
         clear_flagged_images_gpu(images);
     }
 

--- a/src/rfi_flagging.hpp
+++ b/src/rfi_flagging.hpp
@@ -39,7 +39,7 @@ std::pair<T, T> compute_running_rms(const std::vector<T>& values, int threshold 
     size_t count {0};
     T sum {0}, sum2 {0}, mean {0}, rms {0};
     for(const T& val : values){
-        if(!std::isnan(val) && !std::isinf(val) && (std::abs(val - mean_all) / stdev) < threshold ){
+        if(!std::isnan(val) && !std::isinf(val) && (threshold < 0 || (std::abs(val - mean_all) / stdev) < threshold)){
             sum += val;
             sum2 += val*val;
             count += 1;   

--- a/src/timestep_rfi_flagging.cpp
+++ b/src/timestep_rfi_flagging.cpp
@@ -1,0 +1,84 @@
+
+#include <cmath>
+#include <iostream>
+#include <mycomplex.hpp>
+#include <images.hpp>
+#include "rfi_flagging.hpp"
+#ifdef __GPU__
+#include "gpu/timestep_rfi_flagging_gpu.hpp"
+#endif
+
+
+std::vector<float> compute_timestep_rms_cpu(Images& images){
+    size_t centre {images.side_size / 2};
+    std::vector<float> rms_vector(images.n_intervals);
+    #pragma omp parallel for schedule(static)
+    for(size_t i {0u}; i < images.n_intervals; i++){
+        std::vector<float> values;
+        for(size_t j {0u}; j < images.n_channels; j++){
+            float val {(images.at(i, j) + centre * images.side_size + centre)->real()};
+            values.push_back(val);
+        }
+        auto p = compute_running_rms(values, -1);
+        rms_vector[i] = p.second;
+    }
+    return rms_vector;
+}
+
+
+/**
+    @brief: computes a vector of boolean values indicating which of the input images are contaminated
+    by RFI. The function uses a high RMS as a signal for bad/corrupted channels.
+*/
+void flag_timestep_rfi(Images& images, double rms_threshold, bool use_iqr){
+    std::vector<float> rms_vector;
+    #ifdef __GPU__
+    if(gpu_support() && num_available_gpus() > 0 && images.on_gpu()){
+        rms_vector = compute_timestep_rms_gpu(images);
+    }else{
+        rms_vector = compute_timestep_rms_cpu(images);
+    }
+    #else
+    rms_vector = compute_timestep_rms_cpu(images);
+    #endif
+    
+    std::pair<float, float> median_rms_of_rms = use_iqr ? compute_iqr_rms(rms_vector) : compute_running_rms(rms_vector);
+    float min_rms {*std::min_element(rms_vector.begin(), rms_vector.end())};
+    std::cout << "flag_timestep_rfi - "
+    "min rms: " << *std::min_element(rms_vector.begin(), rms_vector.end()) << ", "
+    "max rms: " << *std::max_element(rms_vector.begin(), rms_vector.end()) << ", "
+    "median = " << median_rms_of_rms.first << ", "
+    "rms = " << median_rms_of_rms.second <<  std::endl;
+    std::vector<bool> new_flags(images.size(), false);
+    auto existing_flags = images.get_flags();
+    if(existing_flags.size() > 0){
+        std::cout << "flag_timestep_rfi: flags are already there.." << std::endl;
+        for(int i {0}; i < existing_flags.size(); i++)
+            new_flags[i] = existing_flags[i];
+    }
+    
+    std::vector<size_t> flagged_ts;
+    // now compute avg rms of all rms
+    for(size_t i {0}; i < rms_vector.size(); i++){
+        if(rms_vector[i] > min_rms * 3){
+            flagged_ts.push_back(i);
+            // flag all images in the timestep
+            std::cout << "flag_timestep_rfi: flagging step " << i << std::endl;
+            for(size_t j {0}; j < images.n_channels; j++)
+                new_flags[i * images.n_channels + j] = true;
+        }
+    }
+    if(flagged_ts.size() > 4){
+        // flags all the steps in between the minimum and maximum flagged timestep
+        // as an aggressive measure
+        size_t min_ts {*std::min_element(flagged_ts.begin(), flagged_ts.end())};
+        size_t max_ts {*std::max_element(flagged_ts.begin(), flagged_ts.end())};
+        for(size_t i {min_ts}; i < max_ts; i++){
+            // flag all images in the timestep
+            std::cout << "flag_timestep_rfi: extra flagging step " << i << std::endl;
+            for(size_t j {0}; j < images.n_channels; j++)
+                new_flags[i * images.n_channels + j] = true;
+        }
+    }
+    images.set_flags(new_flags);
+}

--- a/src/timestep_rfi_flagging.hpp
+++ b/src/timestep_rfi_flagging.hpp
@@ -1,0 +1,6 @@
+#ifndef __TIMESTEP_RFI__
+#define __TIMESTEP_RFI__
+
+void flag_timestep_rfi(Images& images, double rms_threshold, bool use_iqr);
+
+#endif


### PR DESCRIPTION
This uses the same principle Marcin defined: "total power" or, better rms of power across the band within one time step. However, in the pipeline we only process one coarse channel at a time, so it will have to do.

We compute the rms for each time step in a second, and if the rms is greater than 3 times the minimum rms, then we flag the timestep. The above may seem very aggressive, but I find that rms does not vary very much across "good" timesteps. On average, rms of rms is 1.x on a good second of data. In bad seconds, rms of rms goes up to 16 and above. Hence, the usual threshold based on median and rms of rms is not really effective in eliminating all RFI.

Furthermore, if more than 4 timesteps are flagged, we also flag all the timesteps in between them.

Here is a dynamic spectrum with RFI, before and after mitigation. Notice how the scale went down one order of magnitude. 
Early experiments show my pulsar detections are not compromised by the procedure, but it is still under testing. On this observation, the output bin file went from 3.8GB to 1.2GB. So good progress, but post processing with @marcinsokolowski tool is still necessary.

<img width="1221" height="843" alt="image" src="https://github.com/user-attachments/assets/c95a046b-84da-4f7b-9c04-b63fe3a71d6f" />

