### PR TITLE
correction : excluding also if RMS drops before the lower threshold -> this can also by strong RFI

### DIFF
--- a/apps/exclude_ranges_totalpower.cpp
+++ b/apps/exclude_ranges_totalpower.cpp
@@ -101,7 +101,7 @@ void find_exclude_ranges( vector<cTotalPower>& total_power_vec, const char* outf
    int last_range_start = -1, last_range_end = -1;
    int count_exclude_range=0;
    for(int i=running_median_size;i<n_points;i++){  // skips first 50 (number of points in the running median) - so before running median / iqr stabilise 
-      if( total_power_vec[i].total_power > total_power_vec[i].up ){
+      if( total_power_vec[i].total_power > total_power_vec[i].up || total_power_vec[i].total_power < total_power_vec[i].down ){
          if( start_range < 0 ){
             if( last_range_end>=0 && (i-last_range_end)<border ){
                // if small break between ranges - extend the current range :


### PR DESCRIPTION
I've realised (by experience) that drops in RMS of total power also produce false candidates - see the attached image. So, I've extended the criterion to exclude these too. I recommend that you update your code too and merge this change to the main branch as well.
<img width="1771" height="917" alt="Drop_in_total_power" src="https://github.com/user-attachments/assets/93a053ec-d233-46a2-b12f-2ec55fee67c2" />
